### PR TITLE
Add Vite-based React frontend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ secrets.json
 # Clés Firebase/Google
 firebase-adminsdk-*.json
 google-services.json
+# Node and frontend
+**/node_modules/
+**/dist/
+**/.expo/

--- a/frontend/mobile/App.tsx
+++ b/frontend/mobile/App.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text>CAPSI Santé Mobile</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});

--- a/frontend/mobile/api.ts
+++ b/frontend/mobile/api.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: 'https://localhost:7069/api'
+});
+
+export default api;

--- a/frontend/mobile/app.json
+++ b/frontend/mobile/app.json
@@ -1,0 +1,8 @@
+{
+  "expo": {
+    "name": "CAPSI Sante",
+    "slug": "capsi-sante-mobile",
+    "version": "1.0.0",
+    "sdkVersion": "50.0.0"
+  }
+}

--- a/frontend/mobile/package.json
+++ b/frontend/mobile/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "capsi-sante-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.73.4",
+    "axios": "^1.6.7"
+  },
+  "devDependencies": {
+    "@types/react": "~18.2.0",
+    "typescript": "^5.4.3"
+  }
+}

--- a/frontend/mobile/tsconfig.json
+++ b/frontend/mobile/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CAPSI Santé</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "capsi-sante-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.14",
+    "@vitejs/plugin-react": "^4.0.3",
+    "typescript": "^5.4.3",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/web/src/App.tsx
+++ b/frontend/web/src/App.tsx
@@ -1,0 +1,12 @@
+import PatientForm from './components/PatientForm';
+import PatientList from './components/PatientList';
+
+export default function App() {
+  return (
+    <div>
+      <h1>CAPSI Santé</h1>
+      <PatientForm />
+      <PatientList />
+    </div>
+  );
+}

--- a/frontend/web/src/api.ts
+++ b/frontend/web/src/api.ts
@@ -1,0 +1,31 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: '/api'
+});
+
+export interface Patient {
+  id: string;
+  numeroAssuranceMaladie: string;
+  nom: string;
+  prenom: string;
+  dateNaissance: string;
+  sexe: string;
+  telephone?: string;
+  email?: string;
+  adresse?: string;
+  codePostal?: string;
+  ville?: string;
+  groupeSanguin?: string;
+  photoUrl?: string;
+}
+
+export const getPatients = () => api.get<Patient[]>('/Patient');
+export const getPatient = (id: string) => api.get<Patient>(`/Patient/${id}`);
+export const createPatient = (patient: Omit<Patient, 'id'>) =>
+  api.post<Patient>('/Patient', patient);
+export const updatePatient = (patient: Patient) =>
+  api.put<Patient>(`/Patient/${patient.id}`, patient);
+export const deletePatient = (id: string) => api.delete(`/Patient/${id}`);
+
+export default api;

--- a/frontend/web/src/components/PatientForm.tsx
+++ b/frontend/web/src/components/PatientForm.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { createPatient, Patient } from '../api';
+
+const empty: Omit<Patient, 'id'> = {
+  numeroAssuranceMaladie: '',
+  nom: '',
+  prenom: '',
+  dateNaissance: '',
+  sexe: '',
+  telephone: '',
+  email: '',
+  adresse: '',
+  codePostal: '',
+  ville: '',
+  groupeSanguin: '',
+  photoUrl: ''
+};
+
+export default function PatientForm() {
+  const [patient, setPatient] = useState(empty);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPatient({ ...patient, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await createPatient(patient);
+    setPatient(empty);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input name="nom" value={patient.nom} onChange={handleChange} placeholder="Nom" />
+      <input name="prenom" value={patient.prenom} onChange={handleChange} placeholder="Prénom" />
+      <button type="submit">Ajouter</button>
+    </form>
+  );
+}

--- a/frontend/web/src/components/PatientList.tsx
+++ b/frontend/web/src/components/PatientList.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { getPatients, deletePatient, Patient } from '../api';
+
+export default function PatientList() {
+  const [patients, setPatients] = useState<Patient[]>([]);
+
+  const load = async () => {
+    const { data } = await getPatients();
+    setPatients((data as any).data || data);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleDelete = async (id: string) => {
+    await deletePatient(id);
+    load();
+  };
+
+  return (
+    <div>
+      <h2>Patients</h2>
+      <ul>
+        {patients.map(p => (
+          <li key={p.id}>
+            {p.nom} {p.prenom}
+            <button onClick={() => handleDelete(p.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/web/src/main.tsx
+++ b/frontend/web/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/web/tsconfig.json
+++ b/frontend/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/frontend/web/vite.config.ts
+++ b/frontend/web/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'https://localhost:7069',
+        changeOrigin: true,
+        secure: false
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add gitignore rules for node and dist artifacts
- scaffold a web React project using Vite and TypeScript
- setup proxy to .NET API running on port 7069
- add minimal Patient CRUD components
- scaffold a mobile project using Expo

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843aea91ce88330ab5b1f2d14c93392